### PR TITLE
Use gettext_lazy to translate strings loaded on module import

### DIFF
--- a/feincmstools/base.py
+++ b/feincmstools/base.py
@@ -3,7 +3,7 @@ import sys, types
 from django.conf import settings
 from django.db import models
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from feincms.models import Base, Template
 from mptt.models import MPTTModel, MPTTModelBase

--- a/feincmstools/models.py
+++ b/feincmstools/models.py
@@ -3,7 +3,7 @@ import os
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string, find_template
 from django.template.context import RequestContext, Context
 from django.template import TemplateDoesNotExist


### PR DESCRIPTION
This avoids some potential weird circular imports, and also ensures the strings get properly translated on the fly.
